### PR TITLE
real execution time stats

### DIFF
--- a/pages/api/maze-c.ts
+++ b/pages/api/maze-c.ts
@@ -134,14 +134,17 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
     let tick = 0.0;
 
     const svgHeader = renderStart();
+    const generateAndSolveStart = new Date().getTime();
     exports.generate_and_solve_maze(MAZE_SIZE.x, MAZE_SIZE.y, seed);
+    const generateAndSolveEnd = new Date().getTime();
     const svgFooter = renderEnd();
 
     const svg = [ svgHeader, svgMaze.join("\n"), svgSolution.join("\n"), svgFooter ].join("\n");
 
     return new Response(svg, {
         headers: {
-            "Content-Type": "image/svg+xml"
+            "Content-Type": "image/svg+xml",
+            "Execution-Time": (generateAndSolveEnd - generateAndSolveStart).toString(),
         }
     });
 }

--- a/pages/api/maze-c.ts
+++ b/pages/api/maze-c.ts
@@ -141,10 +141,13 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
 
     const svg = [ svgHeader, svgMaze.join("\n"), svgSolution.join("\n"), svgFooter ].join("\n");
 
-    return new Response(svg, {
+    const response = await new Response(svg, {
         headers: {
             "Content-Type": "image/svg+xml",
-            "Execution-Time": (new Date().getTime() - generateAndSolveStart).toString(),
         }
     });
+
+    response.headers.set("execution-time", (new Date().getTime() - generateAndSolveStart).toString())
+
+    return response
 }

--- a/pages/api/maze-c.ts
+++ b/pages/api/maze-c.ts
@@ -88,6 +88,8 @@ function renderEnd() {
 }
 
 export default async function handler(req: NextRequest, event: Event): Promise<Response> {
+    const generateAndSolveStart = new Date().getTime();
+
     const { searchParams } = new URL(req.url);
     let seed: number;
 
@@ -134,9 +136,7 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
     let tick = 0.0;
 
     const svgHeader = renderStart();
-    const generateAndSolveStart = new Date().getTime();
-    exports.generate_and_solve_maze(MAZE_SIZE.x, MAZE_SIZE.y, seed);
-    const generateAndSolveEnd = new Date().getTime();
+    exports.generate_and_solve_maze(MAZE_SIZE.x, MAZE_SIZE.y, seed)
     const svgFooter = renderEnd();
 
     const svg = [ svgHeader, svgMaze.join("\n"), svgSolution.join("\n"), svgFooter ].join("\n");
@@ -144,7 +144,7 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
     return new Response(svg, {
         headers: {
             "Content-Type": "image/svg+xml",
-            "Execution-Time": (generateAndSolveEnd - generateAndSolveStart).toString(),
+            "Execution-Time": (new Date().getTime() - generateAndSolveStart).toString(),
         }
     });
 }

--- a/pages/api/maze-js.ts
+++ b/pages/api/maze-js.ts
@@ -384,6 +384,8 @@ function generateAndSolveMaze() {
 }
 
 export default async function handler(req: NextRequest, event: Event): Promise<Response> {
+    const generateAndSolveStart = new Date().getTime();
+
     const { searchParams } = new URL(req.url);
     const seed = searchParams.get('seed');
 
@@ -398,9 +400,7 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
     }
 
     const svgHeader = renderStart();
-    const generateAndSolveStart = new Date().getTime();
     const svgMazeAndSolution = generateAndSolveMaze();
-    const generateAndSolveEnd = new Date().getTime();
     const svgFooter = renderEnd();
 
     const svg = [ svgHeader, svgMazeAndSolution, svgFooter ].join("\n");
@@ -408,7 +408,7 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
     return new Response(svg, {
         headers: {
             "Content-Type": "image/svg+xml",
-            "Execution-Time": (generateAndSolveEnd - generateAndSolveStart).toString(),
+            "Execution-Time": (new Date().getTime() - generateAndSolveStart).toString(),
         }
     });
 }

--- a/pages/api/maze-js.ts
+++ b/pages/api/maze-js.ts
@@ -398,14 +398,17 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
     }
 
     const svgHeader = renderStart();
+    const generateAndSolveStart = new Date().getTime();
     const svgMazeAndSolution = generateAndSolveMaze();
+    const generateAndSolveEnd = new Date().getTime();
     const svgFooter = renderEnd();
 
     const svg = [ svgHeader, svgMazeAndSolution, svgFooter ].join("\n");
 
     return new Response(svg, {
         headers: {
-            "Content-Type": "image/svg+xml"
+            "Content-Type": "image/svg+xml",
+            "Execution-Time": (generateAndSolveEnd - generateAndSolveStart).toString(),
         }
     });
 }

--- a/pages/api/maze-js.ts
+++ b/pages/api/maze-js.ts
@@ -405,10 +405,13 @@ export default async function handler(req: NextRequest, event: Event): Promise<R
 
     const svg = [ svgHeader, svgMazeAndSolution, svgFooter ].join("\n");
 
-    return new Response(svg, {
+    const response = await new Response(svg, {
         headers: {
             "Content-Type": "image/svg+xml",
-            "Execution-Time": (new Date().getTime() - generateAndSolveStart).toString(),
         }
     });
+
+    response.headers.set("execution-time", (new Date().getTime() - generateAndSolveStart).toString())
+
+    return response
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,9 +19,9 @@ const Home: NextPage = () => {
             jsResponse.text(),
             wasmResponse.text()
         ]).then(([ jsSvg, wasmSvg ]) => {
-            document.querySelector("#jsExecutionTime").innerHTML = `${jsResponse.headers.get("Execution-Time")} ms`
+            document.querySelector("#jsExecutionTime").innerHTML = `${jsResponse.headers.get("execution-time")} ms`
             document.querySelector("#mazeJs").innerHTML = jsSvg;
-            document.querySelector("#wasmExecutionTime").innerHTML = `${wasmResponse.headers.get("Execution-Time")} ms`
+            document.querySelector("#wasmExecutionTime").innerHTML = `${wasmResponse.headers.get("execution-time")} ms`
             document.querySelector("#mazeWasm").innerHTML = wasmSvg;
         });
     });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,9 @@ const Home: NextPage = () => {
             jsResponse.text(),
             wasmResponse.text()
         ]).then(([ jsSvg, wasmSvg ]) => {
+            document.querySelector("#jsExecutionTime").innerHTML = `${jsResponse.headers.get("Execution-Time")} ms`
             document.querySelector("#mazeJs").innerHTML = jsSvg;
+            document.querySelector("#wasmExecutionTime").innerHTML = `${wasmResponse.headers.get("Execution-Time")} ms`
             document.querySelector("#mazeWasm").innerHTML = wasmSvg;
         });
     });
@@ -49,7 +51,7 @@ const Home: NextPage = () => {
         <div id="mazeContainer" className={styles.mazeContainer}>
           <div className={styles.mazeWithTitle}>
             <div className={styles.mazeTitle}>
-              JavaScript &mdash; 81ms average
+              JavaScript &mdash; <span id="jsExecutionTime">81ms average</span>
             </div>
 
             <div id="mazeJs" className={styles.maze} />
@@ -57,7 +59,7 @@ const Home: NextPage = () => {
 
           <div className={styles.mazeWithTitle}>
             <div className={styles.mazeTitle}>
-              Wasm (C) &mdash; 36ms average
+              Wasm (C) &mdash; <span id="wasmExecutionTime">36ms average</span>
             </div>
 
             <div id="mazeWasm" className={styles.maze} />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"


### PR DESCRIPTION
Originally, I wanted to make the ANIMATION_DELAY reflect the execution time as well, but its a paradox because the wasm / js function solves AND renders so we would need to split apart the solve and render methods and then plug in the solve time to the render method... Probably overkill.

<img width="1068" alt="Screen Shot 2022-08-27 at 7 34 35 PM" src="https://user-images.githubusercontent.com/36115192/187051515-4e7efa0e-e8f4-4df1-86cb-6ed46654c57b.png">